### PR TITLE
Log_hours & Return Methods

### DIFF
--- a/lib/boat.rb
+++ b/lib/boat.rb
@@ -1,5 +1,6 @@
 class Boat
   attr_reader :type, :price_per_hour, :hours_rented
+  attr_writer :hours_rented
 
   def initialize(type, price_per_hour)
     @type = type

--- a/lib/dock.rb
+++ b/lib/dock.rb
@@ -1,10 +1,11 @@
 class Dock
-  attr_reader :name, :max_rental_time, :rental_log
+  attr_reader :name, :max_rental_time, :rental_log, :revenue
 
   def initialize(name, max_rental_time)
     @name = name
     @max_rental_time = max_rental_time
     @rental_log = {}
+    @revenue = 0
   end
 
   def rent(boat,renter)
@@ -21,6 +22,21 @@ class Dock
         boat.price_per_hour * max_rental_time
       end
     }
+  end
+
+  def log_hour
+    @rental_log.each do |boat, renter|
+      boat.hours_rented += 1
+    end
+  end
+
+  def return(boat)
+    if boat.hours_rented <= max_rental_time
+      @revenue += (boat.hours_rented * boat.price_per_hour)
+    else
+      @revenue += (boat.price_per_hour * max_rental_time)
+    end
+    @rental_log.delete(boat)
   end
 
 end

--- a/spec/dock_spec.rb
+++ b/spec/dock_spec.rb
@@ -57,8 +57,41 @@ RSpec.describe Dock do
       :amount => 45
     }
     expect(dock.charge(sup_1)).to eq(expected2)
-    require 'pry';binding.pry
-
   end
 
+  it "can log hours to all boats at once and return boats" do
+    dock = Dock.new("The Rowing Dock", 3)
+    kayak_1 = Boat.new(:kayak, 20)
+    kayak_2 = Boat.new(:kayak, 20)
+    canoe = Boat.new(:canoe, 25)
+    sup_1 = Boat.new(:standup_paddle_board, 15)
+    sup_2 = Boat.new(:standup_paddle_board, 15)
+    patrick = Renter.new("Patrick Star", "4242424242424242")
+    eugene = Renter.new("Eugene Crabs", "1313131313131313")
+    dock.rent(kayak_1, patrick)
+    dock.rent(kayak_2, patrick)
+    dock.log_hour
+    expect(kayak_1.hours_rented).to eq(1)
+    expect(kayak_2.hours_rented).to eq(1)
+    dock.rent(canoe, patrick)
+    dock.log_hour
+    expect(kayak_1.hours_rented).to eq(2)
+    expect(kayak_2.hours_rented).to eq(2)
+    expect(canoe.hours_rented).to eq(1)
+    expect(dock.revenue).to eq(0)
+    dock.return(kayak_1)
+    dock.return(kayak_2)
+    dock.return(canoe)
+    expect(dock.revenue).to eq(105)
+    expect(dock.rental_log).to eq({})
+    dock.rent(sup_1, eugene)
+    dock.rent(sup_2, eugene)
+    5.times do
+      dock.log_hour
+    end
+    dock.return(sup_1)
+    dock.return(sup_2)
+    expect(dock.revenue).to eq(195)
+    expect(dock.rental_log).to eq({})
+  end
 end


### PR DESCRIPTION
What does this PR do?

Added method to log hour to all boats currently rented, and ability to "return" a boat which removes it from the rental log, and charges the correct amount of revenue to the dock in which it is associated with